### PR TITLE
Add Renovate bot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    ":maintainLockFilesWeekly",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackagePatterns": ["*"]
+    },
+    {
+      "groupName": "github actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"]
+    },
+    {
+      "description": "Group golangci-lint updates specifically",
+      "matchPackageNames": ["golangci/golangci-lint-action"],
+      "groupName": "golangci-lint"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": true,
+    "assignees": ["@nikoksr"]
+  },
+  "timezone": "Europe/Berlin",
+  "schedule": ["before 9am on monday"]
+}


### PR DESCRIPTION
## Summary

This PR adds Renovate bot configuration for automated dependency management.

## Configuration Details

### Update Strategy
- Uses Renovate's best practices configuration
- Maintains lock files weekly (though assert-go has no dependencies currently)
- Pins GitHub Actions to commit digests for enhanced security
- Runs go mod tidy after updates

### Auto-merge Rules
- Minor and patch updates are auto-merged (requires GitHub repo setting)
- Security vulnerabilities are auto-merged
- Platform auto-merge enabled (note: requires repo setting to be enabled)

### Grouping
- Groups all minor/patch updates together
- Separate group for GitHub Actions updates
- Dedicated group for golangci-lint updates

### Security
- Vulnerability alerts labeled with 'security'
- Auto-assigned to @nikoksr
- Auto-merge enabled for security fixes

### Schedule
- Runs before 9am on Mondays (Europe/Berlin timezone)
- Prevents update noise during the week

## Notes

The platformAutomerge feature requires the GitHub repository setting to allow auto-merge. If this is not enabled, Renovate will create PRs but won't auto-merge them.